### PR TITLE
Reset state after error

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -77,7 +77,13 @@ func (s *Scanner) Transform(input []byte) ([]byte, error) {
 func (s *Scanner) consumeWithError(char rune) error {
 	defer func() { s.location.Advance(char) }()
 
-	return s.consume(char)
+	err := s.consume(char)
+	if err != nil {
+		s.state = ssDefault
+		s.currentExpression.Reset()
+	}
+
+	return err
 }
 
 func (s *Scanner) consume(char rune) error {

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -55,7 +55,7 @@ func TestScanner(t *testing.T) {
 				g.BeforeEach(func() { input = []byte("Hello, ${{ world }!") })
 
 				g.It("should fail with the location", func() {
-					Expect(err).To(MatchError("line 1, column 19: unexpected character '!', expected '}'; line 1, column 20: unexpected end of input"))
+					Expect(err).To(MatchError("line 1, column 19: unexpected character '!', expected '}'"))
 					Expect(output).To(BeNil())
 				})
 			})
@@ -72,7 +72,7 @@ func TestScanner(t *testing.T) {
 					g.BeforeEach(func() { evaluateCall.Return("", errors.New("error")) })
 
 					g.It("should fail with the location", func() {
-						Expect(err).To(MatchError("line 1, column 19: error; line 1, column 20: unexpected character '!', expected '}'; line 1, column 21: unexpected end of input"))
+						Expect(err).To(MatchError("line 1, column 19: error"))
 						Expect(output).To(BeNil())
 					})
 				})


### PR DESCRIPTION
Assume that a variable was not a special input block and reset state to start looking for the next input after an error.

We now produce correct errors:
![image](https://user-images.githubusercontent.com/40318863/210360096-0582a6b4-1922-4d9a-b1b9-e73d97ce60a5.png)
