### PR TITLE
fix: newlines not increased correctly

### DIFF
--- a/e2e/multiline_errors_test.go
+++ b/e2e/multiline_errors_test.go
@@ -1,0 +1,141 @@
+package e2e_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacelift-io/celplate"
+	"github.com/spacelift-io/celplate/evaluator"
+	"github.com/spacelift-io/celplate/source"
+)
+
+// TestMultilineErrorReporting verifies that errors on different lines
+// report the correct line numbers in error messages.
+func TestMultilineErrorReporting(t *testing.T) {
+	// Create an evaluator with some inputs, but missing the ones we'll reference
+	eval, err := evaluator.NewCEL(map[string]map[string]any{
+		"inputs": {
+			"existing": "value",
+		},
+	})
+	require.NoError(t, err)
+
+	// Test case 1: Errors on different lines should report correct line numbers
+	t.Run("errors on different lines", func(t *testing.T) {
+		input := `first line # with a trailing comment
+second line with ${{ inputs.missing1 }} expression
+third line
+fourth line with ${{ inputs.missing2 }} expression`
+
+		scanner := celplate.NewScanner(eval)
+		_, err := scanner.Transform([]byte(input))
+
+		require.Error(t, err)
+
+		// Check that we get source.Errors with multiple errors
+		errs := source.GetErrors(err)
+		assert.Len(t, errs, 2)
+
+		// First error should be on line 2
+		assert.Equal(t, 2, errs[0].Location.Line)
+		assert.Contains(t, errs[0].Message, "no such key: missing1")
+
+		// Second error should be on line 4
+		assert.Equal(t, 4, errs[1].Location.Line)
+		assert.Contains(t, errs[1].Message, "no such key: missing2")
+	})
+
+	// Test case 2: Multiple errors on the same line
+	t.Run("multiple errors on same line", func(t *testing.T) {
+		input := `first line
+second line with ${{ inputs.missing1 }} and ${{ inputs.missing2 }}
+third line`
+
+		scanner := celplate.NewScanner(eval)
+		_, err := scanner.Transform([]byte(input))
+
+		require.Error(t, err)
+
+		errs := source.GetErrors(err)
+		assert.Len(t, errs, 2)
+
+		// Both errors should be on line 2
+		assert.Equal(t, 2, errs[0].Location.Line)
+		assert.Equal(t, 2, errs[1].Location.Line)
+
+		// Column numbers should be different
+		assert.NotEqual(t, errs[0].Location.Column, errs[1].Location.Column)
+	})
+
+	// Test case 3: Error after comment lines
+	t.Run("error after comment lines", func(t *testing.T) {
+		input := `# This is a comment
+# Another comment line
+third line with ${{ inputs.missing }} expression`
+
+		scanner := celplate.NewScanner(eval)
+		_, err := scanner.Transform([]byte(input))
+
+		require.Error(t, err)
+
+		errs := source.GetErrors(err)
+		assert.Len(t, errs, 1)
+
+		// Error should be on line 3 (after two comment lines)
+		assert.Equal(t, 3, errs[0].Location.Line)
+		assert.Contains(t, errs[0].Message, "no such key: missing")
+	})
+
+	// Test case 4: Complex YAML-like structure
+	t.Run("complex yaml structure", func(t *testing.T) {
+		input := `stacks:
+  - name: ${{ inputs.missing_name }}-stack
+    description: ${{ inputs.missing_desc }}
+    config:
+      region: us-east-1
+      environment: ${{ inputs.missing_env }}`
+
+		scanner := celplate.NewScanner(eval)
+		_, err := scanner.Transform([]byte(input))
+
+		require.Error(t, err)
+
+		errs := source.GetErrors(err)
+		assert.Len(t, errs, 3)
+
+		// Verify line numbers for each error
+		assert.Equal(t, 2, errs[0].Location.Line, "first error should be on line 2")
+		assert.Contains(t, errs[0].Message, "missing_name")
+
+		assert.Equal(t, 3, errs[1].Location.Line, "second error should be on line 3")
+		assert.Contains(t, errs[1].Message, "missing_desc")
+
+		assert.Equal(t, 6, errs[2].Location.Line, "third error should be on line 6")
+		assert.Contains(t, errs[2].Message, "missing_env")
+	})
+
+	// Test case 5: Verify error message format
+	t.Run("error message format", func(t *testing.T) {
+		input := `line one
+line two with ${{ inputs.missing }} error
+line three`
+
+		scanner := celplate.NewScanner(eval)
+		_, err := scanner.Transform([]byte(input))
+
+		require.Error(t, err)
+
+		// The error message should contain the line number
+		assert.Contains(t, err.Error(), "line 2")
+
+		errs := source.GetErrors(err)
+		assert.Len(t, errs, 1)
+
+		// The formatted error should show "line 2, column X"
+		errorStr := errs[0].Error()
+		assert.True(t, strings.HasPrefix(errorStr, "line 2, column"))
+	})
+}

--- a/scanner.go
+++ b/scanner.go
@@ -65,6 +65,9 @@ func (s *Scanner) Transform(input []byte) ([]byte, error) {
 			s.output.Write(line)
 			if ix != len(lines)-1 {
 				s.output.Write([]byte("\n"))
+				// Increment the line if it's a comment since we're skipping line evaluation
+				// This is to keep the line location correct
+				s.location.Advance('\n')
 			}
 			continue
 		}
@@ -77,6 +80,7 @@ func (s *Scanner) Transform(input []byte) ([]byte, error) {
 
 		if ix != len(lines)-1 {
 			s.output.Write([]byte("\n"))
+			s.location.Advance('\n')
 		}
 	}
 


### PR DESCRIPTION
Fix line number tracking in scanner error reporting.

The scanner was not advancing location tracking for newline characters, causing all CEL expression errors to be reported as "line 1" regardless of their actual position. This made debugging multi-line templates difficult.

Added location.Advance('\n') calls after writing newlines to maintain accurate line/column tracking for error messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to newline bookkeeping plus new tests; low risk aside from potential off-by-one behavior in error locations.
> 
> **Overview**
> Fixes `Scanner.Transform` location tracking by advancing `source.Location` on every emitted newline, including comment-only lines that skip evaluation, so CEL evaluation errors report correct line/column numbers instead of collapsing to line 1.
> 
> Adds an end-to-end test (`e2e/multiline_errors_test.go`) covering multi-line templates, multiple errors on the same line, comment-prefixed lines, YAML-like content, and error string formatting to prevent regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 141b6fda7929544762c71d2252093e0012572874. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->