### PR TITLE
fix: Parsing $ at the end of the line

### DIFF
--- a/e2e/fixtures/input.yaml
+++ b/e2e/fixtures/input.yaml
@@ -5,7 +5,9 @@ test:
   id: ${{ string(inputs.id) }}
   serial: ${{ inputs.serial }}
   name: ${{ inputs.environment }} in ${{ inputs.region }}
-  description: A simple hello world stack
+  description: |
+    A simple hello world stack
+    A line with dollar sign at the end $
   created_at: ${{ string(context.datetime) }}
   created_at_s: ${{ context.datetime.getSeconds() }}
   delete_at: ${{ 'context.datetime' }}

--- a/e2e/fixtures/output.yaml
+++ b/e2e/fixtures/output.yaml
@@ -5,7 +5,9 @@ test:
   id: 1
   serial: 111111111111
   name: production in us-east-1
-  description: A simple hello world stack
+  description: |
+    A simple hello world stack
+    A line with dollar sign at the end $
   created_at: 2022-04-10T01:01:01.000000001Z
   created_at_s: 1
   delete_at: context.datetime

--- a/scanner.go
+++ b/scanner.go
@@ -79,8 +79,9 @@ func (s *Scanner) Transform(input []byte) ([]byte, error) {
 		}
 
 		if ix != len(lines)-1 {
-			s.output.Write([]byte("\n"))
-			s.location.Advance('\n')
+			if err := s.consumeWithError('\n'); err != nil {
+				errs.Push(err)
+			}
 		}
 	}
 

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -60,6 +60,17 @@ func TestScanner(t *testing.T) {
 				})
 			})
 
+			g.Describe("when the input contains a bare $ at end of a line", func() {
+				g.BeforeEach(func() {
+					input = []byte("pattern: ^[a-z]+$\nrequired: true")
+				})
+
+				g.It("should pass through literally without consuming the next line", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(output).To(Equal(input))
+				})
+			})
+
 			g.Describe("when the input contains an expression", func() {
 				var evaluateCall *mock.Call
 


### PR DESCRIPTION

[Problem parsing $ in Template Migration Flow](https://app.clickup.com/t/2384866/869dubf7e)

Problem reported in template migration as an issue in the migration (stripping quotes) but the real problem is in the template parsing.
- the quotes are optional in YAML syntax - we are not doing anything wrong
- the CEL parser fails to parse the expression when the line ends with `$` sign

The fix:
pass `\n` through the state machine via consumeWithError instead of writing it directly to output.
That makes `ssDollar + \n` behave like `ssDollar + <any non-{>` - writes `$\n` literally and resets to ssDefault in the parser state machine.